### PR TITLE
Use multistage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM golang:1
+FROM golang:1 as build
 WORKDIR /usr/src/app
 COPY . ./
-RUN go build -o ackbar
+RUN CGO_ENABLED=0 GOOS=linux go build -o ackbar
+
+FROM scratch
+
+COPY --from=build /usr/src/app/ackbar /bin/ackbar
 
 EXPOSE 8080
-ENTRYPOINT ["./ackbar"]
+CMD ["/bin/ackbar"]


### PR DESCRIPTION
Using a multi-stage build you could reduce the final docker image size by a factor of 100

<img width="729" alt="Screenshot 2024-06-14 at 12 32 58" src="https://github.com/bespinian/ackbar/assets/21216406/230f1939-cfd4-4da1-b03c-4ed779da68cc">
